### PR TITLE
Use new lord state slot for promoted companions

### DIFF
--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -1122,9 +1122,9 @@ dialogs = [
         (remove_member_from_party, "$g_talk_troop"),(set_player_troop, "trp_player")]],
 
 [anyone|plyr,"member_talk", [
-    #This option is only available if their leadership is 3+
+    #This option is only available if they have ranks in leadership
     (store_skill_level, ":leadership", "skl_leadership", "$g_talk_troop"),
-    (ge, ":leadership", 3),
+    (ge, ":leadership", 1),
 
     #Make sure their faction isn't defeated
     (store_troop_faction, ":troop_faction", "$g_talk_troop"),
@@ -1138,12 +1138,21 @@ dialogs = [
 ], "You should return to {s14} and gather warriors to lead against the enemy.", "member_promote_lord",[]],
 
 [anyone,"member_promote_lord", [
-], "Perhaps you're right. {s14} has need of more capable commanders. Are you sure you're ready for me to leave your side?", "member_promote_lord_2",[]],
+    #Adjust text based on companion's leadership skill to communicate that low leadership companions will be defensive lords
+    (store_skill_level, ":leadership", "skl_leadership", "$g_talk_troop"),
+    (try_begin),
+        (ge, ":leadership", 3),
+        (str_store_string, 15, "@With the skills I have gained I should be able to raise a great host to march on the enemy."),
+    (else_try),
+        (str_store_string, 15, "@I'm not much of a leader, but I will rally defenders to protect my home."),
+    (try_end),
+], "Perhaps you're right. {s14} has need of more capable commanders. {s15} Are you sure you're ready for me to leave your side?", "member_promote_lord_2",[]],
 
 [anyone|plyr, "member_promote_lord_2", [],  "I am sure. You can do more leading a host of your own.", "member_promote_lord_leaving", []],
 [anyone, "member_promote_lord_leaving", [],  "Well. I'll be off, then. Perhaps we will meet again.", "close_window", [
     (call_script,"script_stand_back"),
     (call_script, "script_promote_companion_to_lord", "$g_talk_troop"),
+    (set_player_troop, "trp_player"),
 ]],
 
 #This option is disabled temporarily since it causes a weird loop later on I need to figure out how to fix - Ren
@@ -1187,7 +1196,7 @@ dialogs = [
 [anyone,"member_background_recap_3", [], "Then shortly after, I joined up with you.", "do_member_trade",[]],
 [anyone,"do_member_view_char", [], "Anything else?", "member_talk",[]],
 
-[anyone|plyr,"member_talk", [(eq, "$cheat_mode", 1)], "{!}Become a Lord", "close_window",[(call_script, "script_promote_companion_to_lord", "$g_talk_troop"),]],
+[anyone|plyr,"member_talk", [(eq, "$cheat_mode", 1)], "{!}Become a Lord", "close_window",[(call_script, "script_promote_companion_to_lord", "$g_talk_troop"),(set_player_troop, "trp_player")]],
 
 # ORIGINAL MEMBER HEALTH
 #[anyone,"member_health", [

--- a/ModuleSystem/module_scripts.py
+++ b/ModuleSystem/module_scripts.py
@@ -11723,7 +11723,7 @@ scripts = [
     (troop_get_slot, ":banner_id", ":faction_leader", slot_troop_banner_scene_prop),
     (troop_set_slot, ":troop_no", slot_troop_banner_scene_prop, ":banner_id"),
 
-    #Ren - It might interesting if renown factored in what they did while in the player's party, but level is probably a good enough approximation
+    #Ren - It might be interesting if renown factored in what they did while in the player's party, but level is probably a good enough approximation
     (store_character_level, ":level", ":troop_no"),
     (store_mul, ":renown", ":level", ":level"),
     (val_div, ":renown", 2),
@@ -11736,8 +11736,33 @@ scripts = [
     (troop_set_slot, ":troop_no", slot_troop_prisoner_of_party, -1),
     (call_script, "script_update_troop_notes", ":troop_no"),
 
-    #Create their party in the capital
-    (faction_get_slot, ":town", ":troop_faction",  slot_faction_capital ),
+    (store_skill_level, ":leadership", "skl_leadership", ":troop_no"),
+    (try_begin),
+        #Companions with at least 3 leadership (the minimum among lords) will behave like a normal lord
+        (ge, ":leadership", 3),
+        (troop_set_slot, ":troop_no", slot_troop_lord_state, stls_default),
+    (else_try),
+        #Companions with only 1 or 2 leadership will become defensive lords
+        (ge, ":leadership", 1),
+        (troop_set_slot, ":troop_no", slot_troop_lord_state, stls_defensive),
+    (else_try),
+        #Companions with no leadership skill become passive heroes
+        (troop_set_slot, ":troop_no", slot_troop_lord_state, stls_passive),
+    (try_end),
+
+
+    #Set the troop's home to where they were first met
+    (troop_get_slot, ":town", ":troop_no", slot_troop_first_encountered),
+    (troop_set_slot, ":troop_no", slot_troop_home, ":town"),
+
+    #If troop's home is destroyed spawn their party at the faction capital instead
+    (try_begin),  
+        (this_or_next|party_slot_eq, ":town", slot_center_destroyed, 1),
+        (neg|party_is_active, ":town"),
+        (faction_get_slot, ":town", ":troop_faction", slot_faction_capital),
+    (try_end),
+
+    #Create their party in the appropriate town
     (call_script, "script_create_kingdom_hero_party", ":troop_no", ":town"),
 
     #Give strength to their faction based on their level


### PR DESCRIPTION
Updates the promote companion to lord script to use the new lord state slot:

0 leadership companions become passive
1-2 leadership companions become defensive
3+ leadership companions use the default behavior.

Changed the voluntary promotion to allow promoting 1-2 leadership companions, and added some dynamic dialog to indicate they will behave differently.

Also fixed an issue where player troop wasn't resetting when the companion promotion dialog ended, so the player troop remained the companion if the player updated their skills/equipment first.