### PR TITLE
Companion lord equipment

### DIFF
--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -1989,7 +1989,10 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
 [anyone|plyr, "companion_faction_demolished", [],  "I'm sorry, but we are needed elsewhere.", "close_window", [(call_script,"script_stand_back"),]],
 
 [anyone, "event_triggered", [(eq, "$npc_map_talk_context", slot_troop_last_complaint_hours),],
-"{s5}, I am sorry, but the suffering of {reg6?our:my} {s6} homeland is too great. I must return at once to provide what aid I can.", "companion_faction_dying", []],
+"{s5}, I am sorry, but the suffering of {reg6?our:my} {s6} homeland is too great. I must return at once to provide what aid I can.", "companion_faction_dying_pretalk", []],
+
+[anyone, "companion_faction_dying_pretalk", [],  "Farewell, {s5}.", "companion_faction_dying", [
+]],
 
 [anyone|plyr, "companion_faction_dying", [],  "Very well. Perhaps we will meet again.", "close_window", [
     (call_script,"script_stand_back"),
@@ -2092,6 +2095,18 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
 
 [anyone,"companion_give_troops_final", [],
 "Farewell, commander.", "close_window", [(call_script,"script_stand_back")]],
+
+[anyone|plyr,"companion_faction_dying", [
+    #Don't show this for companions whose inventory isn't accessible
+    (neq, "$g_talk_troop", "trp_npc21"), #Berta
+
+    (store_character_level, ":talk_troop_level", "$g_talk_troop"),
+    (store_character_level, ":player_level", "trp_player"),
+    (val_add, ":player_level", 10),
+    (this_or_next|lt, ":talk_troop_level", ":player_level"),
+    (lt, ":talk_troop_level", 30),
+    ],"Let me see your equipment before you leave.", "companion_faction_dying_trade",[]],
+[anyone,"companion_faction_dying_trade", [], "Very well, it's all here...", "companion_faction_dying_pretalk",[(set_player_troop, "trp_player"),(change_screen_equip_other)]], 
 
 [anyone|plyr, "companion_faction_dying", [],  "I understand, but you are needed here.", "companion_faction_dying_persuade", []],
 

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -9036,12 +9036,18 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 ], "Of course I will return {reg2?these items:this item} to you but it seems like you have no room in your inventory currently. Make some room, then ask me again.", "lord_talk",[]],
 
 [anyone,"lord_return_items", [
+    #Get the captain of their home to use as a template troop to replace any items that are taken
+    #This could be problematic for orc companions since the captains would be uruks, but I don't think any orc armor rewards are unique so it shouldn't matter - Ren
+    (troop_get_slot, ":town", "$g_talk_troop", slot_troop_home),
+    (party_get_slot, ":captain", ":town", slot_town_captain),
+
     (try_for_range, ":slot", ek_item_0, ek_food),
         (troop_get_inventory_slot, ":item", "$g_talk_troop", ":slot"),
         (ge, ":item", 0),
         (item_has_property, ":item", itp_unique),
         (troop_get_inventory_slot_modifier, ":mod", "$g_talk_troop", ":slot"),
-        (troop_set_inventory_slot, "$g_talk_troop", ":slot", -1),   # remove item from NPC
+        (troop_get_inventory_slot, ":replacement_item", ":captain", ":slot"),
+        (troop_set_inventory_slot, "$g_talk_troop", ":slot", ":replacement_item"),   # remove item from NPC
         (troop_add_item, "trp_player", ":item", ":mod"),            # return item to player
     (end_try),
 ], "Of course. Here {reg2?they are:it is}.", "lord_talk",[]],

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -9038,17 +9038,26 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 [anyone,"lord_return_items", [
     #Get the captain of their home to use as a template troop to replace any items that are taken
     #This could be problematic for orc companions since the captains would be uruks, but I don't think any orc armor rewards are unique so it shouldn't matter - Ren
-    (troop_get_slot, ":town", "$g_talk_troop", slot_troop_home),
-    (party_get_slot, ":captain", ":town", slot_town_captain),
+    (call_script, "script_get_template_troop_for_companion", "$g_talk_troop"),
+    (assign, ":template_troop", reg1),
 
     (try_for_range, ":slot", ek_item_0, ek_food),
         (troop_get_inventory_slot, ":item", "$g_talk_troop", ":slot"),
         (ge, ":item", 0),
         (item_has_property, ":item", itp_unique),
         (troop_get_inventory_slot_modifier, ":mod", "$g_talk_troop", ":slot"),
-        (troop_get_inventory_slot, ":replacement_item", ":captain", ":slot"),
-        (troop_set_inventory_slot, "$g_talk_troop", ":slot", ":replacement_item"),   # remove item from NPC
-        (troop_add_item, "trp_player", ":item", ":mod"),            # return item to player
+        (troop_add_item, "trp_player", ":item", ":mod"), # return item to player
+
+        (try_begin),
+            # Give a replacement item if the template has one that is not unique
+            (troop_get_inventory_slot, ":replacement_item", ":template_troop", ":slot"),
+            (neq, ":replacement_item", -1),
+            (neg|item_has_property, ":replacement_item", itp_unique),
+            (troop_set_inventory_slot, "$g_talk_troop", ":slot", ":replacement_item"),
+        (else_try),
+            # Just empty the slot
+            (troop_set_inventory_slot, "$g_talk_troop", ":slot", -1),
+        (try_end),
     (end_try),
 ], "Of course. Here {reg2?they are:it is}.", "lord_talk",[]],
 

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -9015,6 +9015,38 @@ I suppose there are plenty of bounty hunters around to get the job done . . .", 
 
 ##### TODO: QUESTS COMMENT OUT END
 
+[anyone|plyr,"lord_talk", [
+    (this_or_next|is_between, "$g_talk_troop", companions_begin, companions_end),
+    (is_between, "$g_talk_troop", new_companions_begin, new_companions_end),
+    (assign, ":unique_count", 0),
+    (try_for_range, ":slot", ek_item_0, ek_food),
+        (troop_get_inventory_slot, ":item", "$g_talk_troop", ":slot"),
+        (ge, ":item", 0),
+        (item_has_property, ":item", itp_unique),
+        (val_add, ":unique_count", 1),
+    (end_try),
+    (gt, ":unique_count", 0),
+    (assign, reg2, ":unique_count"),
+    (val_sub, reg2, 1),
+], "I need you to return the unique {reg2?items:item} I gave you.", "lord_return_items",[]],
+
+[anyone,"lord_return_items", [
+    (store_free_inventory_capacity,reg1,"trp_player"),
+    (le, reg1, reg2)
+], "Of course I will return {reg2?these items:this item} to you but it seems like you have no room in your inventory currently. Make some room, then ask me again.", "lord_talk",[]],
+
+[anyone,"lord_return_items", [
+    (try_for_range, ":slot", ek_item_0, ek_food),
+        (troop_get_inventory_slot, ":item", "$g_talk_troop", ":slot"),
+        (ge, ":item", 0),
+        (item_has_property, ":item", itp_unique),
+        (troop_get_inventory_slot_modifier, ":mod", "$g_talk_troop", ":slot"),
+        (troop_set_inventory_slot, "$g_talk_troop", ":slot", -1),   # remove item from NPC
+        (troop_add_item, "trp_player", ":item", ":mod"),            # return item to player
+    (end_try),
+], "Of course. Here {reg2?they are:it is}.", "lord_talk",[]],
+
+
 #Leave
 [anyone|plyr,"lord_talk", [(troop_slot_ge, "$g_talk_troop", slot_troop_prisoner_of_party, 0)], "I must leave now.", "lord_leave_prison",[]],
 [anyone|plyr,"lord_talk", [(lt, "$g_talk_troop_faction_relation", 0)], "This little chat is over. I leave now.", "lord_leave",[]],

--- a/ModuleSystem/module_scripts.py
+++ b/ModuleSystem/module_scripts.py
@@ -23408,6 +23408,7 @@ scripts = [
                 (store_relation, ":rel", ":town_faction", ":troop_faction"),
                 (ge, ":rel", 0), #only spawn if friendly center
                 (neg|troop_slot_eq, ":cur_troop", slot_troop_wound_mask, wound_death), # Do not reincarnate if dead
+                (neg|troop_slot_eq, ":cur_troop", slot_troop_occupation, slto_kingdom_hero), # Don't show up here if they've promoted to lord
                 (set_visitor, 8, ":cur_troop"), #only one companion NPC per town!
             (try_end),
         (try_end),

--- a/ModuleSystem/module_scripts.py
+++ b/ModuleSystem/module_scripts.py
@@ -11784,6 +11784,36 @@ scripts = [
         (faction_get_slot, ":town", ":troop_faction", slot_faction_capital),
     (try_end),
 
+    (call_script, "script_get_template_troop_for_companion", ":troop_no"),
+    (assign, ":template_troop", reg1),
+
+    # Compare all of the troop's gear to the template troop and take any items that would be an upgrade
+    (try_for_range, ":slot", ek_item_0, ek_food),
+        (troop_get_inventory_slot, ":troop_item", ":troop_no", ":slot"),
+        (troop_get_inventory_slot, ":template_item", ":template_troop", ":slot"),
+
+        # Skip if the template troop has nothing
+        (neq, ":template_item", -1),
+        # Don't give uniques
+        (neg|item_has_property, ":template_item", itp_unique),
+
+        (try_begin),
+            # If slot is empty then replace it immediately
+            (eq, ":troop_item", -1),
+            (troop_set_inventory_slot, ":troop_no", ":slot", ":template_item"),
+        (else_try),
+            # If slot isn't empty see if replacement is appropriate
+            # Don't replace uniques
+            (neg|item_has_property, ":troop_item", itp_unique),
+
+            # Check if the template item is higher value
+            (store_item_value, ":troop_item_value", ":troop_item"),
+            (store_item_value, ":template_item_value", ":template_item"),
+            (gt, ":template_item_value", ":troop_item_value"),
+            (troop_set_inventory_slot, ":troop_no", ":slot", ":template_item"),
+        (try_end),
+    (end_try),
+
     #Create their party in the appropriate town
     (call_script, "script_create_kingdom_hero_party", ":troop_no", ":town"),
 
@@ -11794,6 +11824,56 @@ scripts = [
     (faction_get_slot, ":fac_strength", ":troop_faction", slot_faction_strength_tmp),
     (val_add, ":fac_strength", ":strength_increase"),
     (faction_set_slot,":troop_faction",slot_faction_strength_tmp,":fac_strength"),
+]),
+
+# script_get_template_troop_for_companion
+# Input: arg1 = troop_no,
+# Output: reg1 - troop_id of troop to use as a template
+("get_template_troop_for_companion", [
+    (store_script_param_1, ":troop_no"),
+    (store_troop_faction, ":troop_faction", ":troop_no"),
+
+    (try_begin),
+        # Can't use the captain troops for orcs because the captains will be uruks
+        (troop_get_type, ":race", ":troop_no"),
+        (eq, ":race", tf_orc),
+        (assign, ":template_troop", -1),
+        # Scan lords for an orc lord of the same faction
+        (try_for_range, ":kingdom_hero", kingdom_heroes_begin, kingdom_heroes_end),
+            (store_troop_faction, ":kingdom_hero_faction", ":kingdom_hero"),
+            (eq, ":kingdom_hero_faction", ":troop_faction"),
+            (troop_get_type, ":kingdom_hero_race", ":kingdom_hero"),
+            (eq, ":kingdom_hero_race", tf_orc),
+            (assign, ":template_troop", ":kingdom_hero"),
+        (try_end),
+
+        (try_begin),
+            (eq, ":template_troop", -1),
+            (assign, ":template_level", 0),
+            # If no suitable lord was found then look for a high level regular
+            (try_for_range, ":soldier", soldiers_begin, soldiers_end),
+                (store_troop_faction, ":soldier_faction", ":soldier"),
+                (eq, ":soldier_faction", ":troop_faction"),
+                (troop_get_type, ":soldier_race", ":soldier"),
+                (eq, ":soldier_race", tf_orc),
+
+                # If the qualified soldier troop is higher level than what we have already use it instead
+                (store_character_level,":level",":soldier"),
+                (gt, ":level", ":template_level"),
+                (assign,":template_troop", ":soldier"),
+            (try_end),
+        (try_end),
+    (else_try),
+        # For anyone other an orc use their home town's captain troop
+        (troop_get_slot, ":town", ":troop_no", slot_troop_home),
+        (party_get_slot, ":template_troop", ":town", slot_town_captain),
+    (try_end),
+    (try_begin),
+        (eq, "$cheat_mode", 1),
+        (str_store_troop_name, s3, ":template_troop"),
+        (display_message, "@{!}DEBUG: Template troop: {s3}"),
+    (try_end),
+    (assign, reg1, ":template_troop"),
 ]),
 
 #  "script_str_store_race_adj" (stringNo, raceNo)  (mtarini)


### PR DESCRIPTION
* Add a dialog option to allow accessing a companion's inventory before they leave to become a lord
* Add a dialog option to request a companion who is already a lord return any unique items the player gave them
* Added a new script to find an appropriate equipment template troop for a companion. Generally it's the captain of their home town, but for orcs it will be an orc lord of their faction, or a high level orc troop if they have no orc lords. When promoted companions will be given gear from the template troop provided is is more valuable than their current gear, and would not give or replace uniques. This is also used to replace any unique items when they are returned to the player.
* Unrelated to equipment, but fixed promoted companions spawning back at their home town recruitment point.