### PR TITLE
Updates to promoting companions to lords

### DIFF
--- a/ModuleSystem/module_constants.py
+++ b/ModuleSystem/module_constants.py
@@ -1055,9 +1055,10 @@ slot_troop_is_berserker = 170
 # Ren - I'm padding these to make it easier to insert more tiers later but at the moment we only need 3
 slot_troop_faction_loyalty = 171
 
+faction_loyalty_disloyal = 3    # Not at all loyal to their home faction
 faction_loyalty_neutral = 5     # Not overly loyal, but not treacherous. Could be a good hero who weighs the interests of all of Middle-Earth over their home
 faction_loyalty_loyal = 10      # Default for most heroes. Loyal to their faction but also concerned about their allies
-faction_loyalty_fanatical = 15 # Will drop everything else for their 
+faction_loyalty_fanatical = 15  # Will drop everything else for their faction
 
 #slot for hardcoding lord behavior - this needs to be stored in a troop slot, so it is consistent over hero defeat and respawn cycles (which reset party ID)
 slot_troop_lord_state = 172

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -2138,6 +2138,13 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
     (store_character_level, ":npc_level", "$map_talk_troop"),
     (store_attribute_level, ":charisma", "trp_player", ca_charisma),
     (ge, ":charisma", ":npc_level"),
+
+    #Rank and faction leader relation penalty for persuading companion to stay
+    (store_mul, ":rank_penalty", ":npc_level", -10),
+    (call_script, "script_increase_rank", "$g_talk_troop_faction", ":rank_penalty"),
+    (faction_get_slot,":leader","$g_talk_troop_faction",slot_faction_leader),
+    (store_mul, ":relation_penalty", ":npc_level", -1),
+    (call_script, "script_change_player_relation_with_troop", ":leader", ":relation_penalty"),
 ], "Perhaps you are right. I can serve {s6} better by fighting at your side.", "close_window", [(call_script,"script_stand_back"),]],
 
 [anyone, "companion_faction_dying_persuade", [], "I'm afraid that {s6} needs me more. Farewell, {s5}.", "close_window", [

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -1126,7 +1126,6 @@ dialogs = [
     (troop_get_slot, ":npc_loyalty", "$g_talk_troop", slot_troop_faction_loyalty),
     (ge, ":npc_loyalty", faction_loyalty_neutral),
     (assign, reg20, ":npc_loyalty"),
-    (display_message, "@Loyalty: {reg20}"),
 
     #This option is only available if they have ranks in leadership
     (store_skill_level, ":leadership", "skl_leadership", "$g_talk_troop"),
@@ -1172,7 +1171,7 @@ dialogs = [
 [anyone|plyr, "member_promote_lord_2", [],  "I am sure. You can do more leading a host of your own.", "member_promote_lord_leaving", []],
 [anyone, "member_promote_lord_leaving", [],  "Well. I'll be off, then. Perhaps we will meet again.", "close_window", [
     (call_script,"script_stand_back"),
-    (call_script, "script_promote_companion_to_lord", "$g_talk_troop"),
+    (call_script, "script_promote_companion_to_lord", "$g_talk_troop", 1),
     (set_player_troop, "trp_player"),
 ]],
 
@@ -1180,7 +1179,7 @@ dialogs = [
 #[anyone|plyr,"member_promote_lord_2", [],
 #"I am sure. I will also send warriors of {s14} with you.", "companion_give_troops",[
 #    #Player can't change their mind now so spawn their party now before attempting the troop exchange
-#    (call_script, "script_promote_companion_to_lord", "$g_talk_troop"),
+#    (call_script, "script_promote_companion_to_lord", "$g_talk_troop", 1),
 #    # just to see if someone can be given away: backup party, then see if troops which can be given away 
 #    (call_script, "script_party_copy", "p_main_party_backup", "p_main_party"),
 #    (call_script, "script_party_split_by_faction", "p_main_party_backup", "p_temp_party", "$g_talk_troop_faction")]],
@@ -1217,7 +1216,7 @@ dialogs = [
 [anyone,"member_background_recap_3", [], "Then shortly after, I joined up with you.", "do_member_trade",[]],
 [anyone,"do_member_view_char", [], "Anything else?", "member_talk",[]],
 
-[anyone|plyr,"member_talk", [(eq, "$cheat_mode", 1)], "{!}Become a Lord", "close_window",[(call_script, "script_promote_companion_to_lord", "$g_talk_troop"),(set_player_troop, "trp_player")]],
+[anyone|plyr,"member_talk", [(eq, "$cheat_mode", 1)], "{!}Become a Lord", "close_window",[(call_script, "script_promote_companion_to_lord", "$g_talk_troop", 0),(set_player_troop, "trp_player")]],
 
 # ORIGINAL MEMBER HEALTH
 #[anyone,"member_health", [
@@ -2017,7 +2016,7 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
 
 [anyone|plyr, "companion_faction_dying", [],  "Very well. Perhaps we will meet again.", "close_window", [
     (call_script,"script_stand_back"),
-    (call_script, "script_promote_companion_to_lord", "$map_talk_troop"),
+    (call_script, "script_promote_companion_to_lord", "$map_talk_troop", 0),
 ]],
 
 #This is adapted from the logic for giving troops to regular lords, but with some of the pre-checks removed because they aren't needed in this context
@@ -2026,7 +2025,7 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
     #Move faction name from s6 to s14 for the troop transfer strings
     (str_store_string_reg, s14, s6),
     #It's now too late for the player to persuade them to stay so spawn their party now before attempting the troop exchange
-    (call_script, "script_promote_companion_to_lord", "$map_talk_troop"),
+    (call_script, "script_promote_companion_to_lord", "$map_talk_troop", 0),
     # just to see if someone can be given away: backup party, then see if troops which can be given away 
     (call_script, "script_party_copy", "p_main_party_backup", "p_main_party"),
     (call_script, "script_party_split_by_faction", "p_main_party_backup", "p_temp_party", "$g_talk_troop_faction")]],
@@ -2143,7 +2142,7 @@ Let's speak again when you are more accomplished.", "close_window", [(call_scrip
 
 [anyone, "companion_faction_dying_persuade", [], "I'm afraid that {s6} needs me more. Farewell, {s5}.", "close_window", [
     (call_script,"script_stand_back"),
-    (call_script, "script_promote_companion_to_lord", "$map_talk_troop"),
+    (call_script, "script_promote_companion_to_lord", "$map_talk_troop", 0),
 ]],
 
 [anyone, "event_triggered", [

--- a/ModuleSystem/module_dialogs.py
+++ b/ModuleSystem/module_dialogs.py
@@ -1122,6 +1122,12 @@ dialogs = [
         (remove_member_from_party, "$g_talk_troop"),(set_player_troop, "trp_player")]],
 
 [anyone|plyr,"member_talk", [
+    #Companions disloyal to their faction can't be made lords
+    (troop_get_slot, ":npc_loyalty", "$g_talk_troop", slot_troop_faction_loyalty),
+    (ge, ":npc_loyalty", faction_loyalty_neutral),
+    (assign, reg20, ":npc_loyalty"),
+    (display_message, "@Loyalty: {reg20}"),
+
     #This option is only available if they have ranks in leadership
     (store_skill_level, ":leadership", "skl_leadership", "$g_talk_troop"),
     (ge, ":leadership", 1),
@@ -1135,6 +1141,21 @@ dialogs = [
     (store_relation, ":rel", "$g_talk_troop_faction", "$players_kingdom"),
     (gt, ":rel", 0),
     (str_store_faction_name, s14, ":troop_faction"),
+
+    #See if the companion's faction has lost any lords
+    (assign, ":lord_killed", 0),
+    (try_for_range, ":troop_no", heroes_begin, heroes_end),
+        (troop_slot_eq, ":troop_no", slot_troop_occupation, slto_kingdom_hero),
+        (store_troop_faction, ":hero_faction_no", ":troop_no"),
+        (eq, "$g_talk_troop_faction", ":hero_faction_no"),
+        (troop_slot_eq, ":troop_no", slot_troop_wound_mask, wound_death),
+        (assign, ":lord_killed", 1),
+    (try_end),
+
+    #Faction must be weak or have lost a lord to send companion back
+    (faction_get_slot, ":npc_faction_strength", "$g_talk_troop_faction", slot_faction_strength),
+    (this_or_next|le, ":npc_faction_strength", fac_str_very_weak),
+    (eq, ":lord_killed", 1),
 ], "You should return to {s14} and gather warriors to lead against the enemy.", "member_promote_lord",[]],
 
 [anyone,"member_promote_lord", [

--- a/ModuleSystem/module_scripts.py
+++ b/ModuleSystem/module_scripts.py
@@ -26099,7 +26099,6 @@ command_cursor_scripts = [
     (try_begin),
         (lt, "$savegame_version", 4338),
         (assign, "$savegame_version", 4338),
-        (call_script, "script_assign_loyalty"),
         #formerly "sitting kings"
         (troop_set_slot, "trp_isengard_lord", slot_troop_lord_state, stls_passive),
         (troop_set_slot, "trp_mordor_lord", slot_troop_lord_state, stls_passive),
@@ -26130,6 +26129,12 @@ command_cursor_scripts = [
             (troop_set_slot, ":has_hp_shield", slot_troop_hp_shield, 100),
             (troop_set_slot, ":has_hp_shield", slot_troop_has_combat_ai, 1),
         (try_end),
+    (try_end),
+
+    (try_begin),
+        (lt, "$savegame_version", 4360),
+        (assign, "$savegame_version", 4360),
+        (call_script, "script_assign_loyalty"),
     (try_end),
     
     (call_script, "script_update_all_notes"),
@@ -28618,7 +28623,7 @@ command_cursor_scripts = [
     (try_end),
     # Override the default for some specificl heroes
     # Berta was a former prisoner of Gundabad
-    (troop_set_slot, trp_npc21, slot_troop_faction_loyalty, faction_loyalty_neutral),
+    (troop_set_slot, trp_npc21, slot_troop_faction_loyalty, faction_loyalty_disloyal),
     # The dwarves only just retook Erebor. Kili will not see them lose it again
     (troop_set_slot, trp_npc7, slot_troop_faction_loyalty, faction_loyalty_fanatical),
 ]),

--- a/ModuleSystem/module_scripts.py
+++ b/ModuleSystem/module_scripts.py
@@ -11727,10 +11727,11 @@ scripts = [
 ]),
 
 # script_promote_companion_to_lord
-# Input: arg1 = troop_no,
+# Input: arg1 = troop_no, arg2 = voluntary
 # Output: none
 ("promote_companion_to_lord", [
     (store_script_param_1, ":troop_no"),
+    (store_script_param_2, ":voluntary"),
 
     #Remove companion from player party
     #Might need to check they are actually in the party if we later decide to allow unrecruited or dismissed heroes to become lords
@@ -11830,6 +11831,16 @@ scripts = [
     (faction_get_slot, ":fac_strength", ":troop_faction", slot_faction_strength_tmp),
     (val_add, ":fac_strength", ":strength_increase"),
     (faction_set_slot,":troop_faction",slot_faction_strength_tmp,":fac_strength"),
+
+    #If player sent companion away voluntarily grant rank and influence rewards
+    (try_begin),
+        (eq, ":voluntary", 1),
+        (faction_get_slot, ":influence", ":troop_faction", slot_faction_influence),
+        (val_add, ":influence", ":level"),
+        (faction_set_slot, ":troop_faction", slot_faction_influence, ":influence"),
+        (store_mul, ":rank_increase", ":level", 10),
+        (call_script, "script_increase_rank", ":troop_faction", ":rank_increase"),
+    (try_end),
 ]),
 
 # script_get_template_troop_for_companion


### PR DESCRIPTION
* Changed requirements for voluntarily sending away a companion. The companion's faction must be weak _or_ have lost a lord already. Additionally disloyal companions (per the new faction loyalty slot) cannot be sent away.
* Added rank and influence reward for voluntarily sending away companions.
* Added rank and faction leader relation penalty for persuading a companion to stay when they try to return to a dying faction